### PR TITLE
support ROC and P/R curves when confidence values are in kw19 files

### DIFF
--- a/scoring_framework/score_tracks_loader.cxx
+++ b/scoring_framework/score_tracks_loader.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2011-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2011-2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -21,6 +21,7 @@
 #include <scoring_framework/score_core.h>
 #include <track_oracle/aries_interface/aries_interface.h>
 #include <track_oracle/track_kwxml/file_format_kwxml.h>
+#include <track_oracle/track_kw18/file_format_kw18.h>
 #ifdef SHAPELIB_ENABLED
 #include <track_oracle/track_apix/file_format_apix.h>
 #endif
@@ -1105,7 +1106,24 @@ input_args_type
 
   xgtf_opts.reset();
   comms_opts.reset();
+
+  // if kw19 hack options are set, use them when reading computed tracks
+  if (kw19_hack())
+  {
+    kwiver::track_oracle::kw18_reader_opts& kw18_opts =
+      dynamic_cast< kwiver::track_oracle::kw18_reader_opts& >(
+        file_format_manager::default_options( kwiver::track_oracle::TF_KW18 ));
+    kw18_opts.set_kw19_hack( true );
+  }
+
   vector< track_record_type > computed_track_records = load_tracks_from_file( computed_src );
+
+  // if kw19, reset reader
+  if (kw19_hack())
+  {
+    file_format_manager::default_options( kwiver::track_oracle::TF_KW18 );
+  }
+
   // However, the computed tracks can be empty if, for example, the tracker missed everything.
 
   // Special VIRAT processing:

--- a/scoring_framework/score_tracks_loader.h
+++ b/scoring_framework/score_tracks_loader.h
@@ -109,6 +109,10 @@ struct SCORE_TRACKS_LOADER_EXPORT input_args_type
   // pair of strings, e.g. "longitude:latitude" or "world_y:world_x"
   vul_arg< std::string > mgrs_lon_lat_fields;
 
+  // If set, assume kw18 will have a 19th column read into the relevancy slot
+  // for each frame. (Computed tracks only.)
+  vul_arg< bool > kw19_hack;
+
   // this flag is not set directly by an input_args command line variable,
   // but instead is set by the main program via other variables (such as
   // e.g. --radial-overlap).  When set, process() tries to compute MGRS geolocation
@@ -136,6 +140,7 @@ struct SCORE_TRACKS_LOADER_EXPORT input_args_type
       track_length_filter("--track-length-filter", "Only keep (truth:computed) tracks with at least this many states (default: all tracks)", "0:0" ),
       time_window(        "--time-window", "Only select tracks within a time window; 'help' for more details" ),
       mgrs_lon_lat_fields("--mgrs-ll-fields", "For e.g. CSV files, pull longitude / latitude from these fields", "world_x:world_y" ),
+      kw19_hack( "--kw19-hack", "If set, read confidence / probability / etc. from 19th column (computed only)" ),
       compute_mgrs_data( false )
   {}
 


### PR DESCRIPTION
This adds the '--kw19-hack' option to score_events, allowing ROC and P/R curves to use the 19th column in a kw18 field for the confidence / probability / likelihood value.

Also adds the '--ct-prefiltered' flag, symmetric to the '--gt-prefiltered' flag. This allows you to generate results without a phony '--a RandomActivity' flag **provided that** all the data in the computed set are relevant.

(Also sets the --n-roc-points default to generate a curve using all the thresholds.)
