### PR TITLE
Replaced use of area method with vgl_area function

### DIFF
--- a/scoring_framework/quickfilter_box.cxx
+++ b/scoring_framework/quickfilter_box.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2012-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2012-2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -8,6 +8,8 @@
 
 #include <stdexcept>
 #include <algorithm>
+
+#include <vgl/vgl_area.h>
 
 #ifdef KWANT_ENABLE_MGRS
 #include <track_oracle/file_formats/track_scorable_mgrs/track_scorable_mgrs.h>
@@ -386,7 +388,7 @@ quickfilter_box_type
     vgl_box_2d<double> overlap = vgl_intersection( t1_box, t2_box );
     if (dbg) LOG_DEBUG( main_logger, "mgrs_box_intersect: boxes:\n" << t1_box << "\n" << t2_box << "\n" << overlap );
 
-    return (overlap.is_empty()) ? 0.0 : overlap.area();
+    return (overlap.is_empty()) ? 0.0 : vgl_area(overlap);
   }
 
   // if we get this far, we found no overlapping zones; the caller will
@@ -428,7 +430,7 @@ quickfilter_box_type
     return -1.0;
   }
 
-  return vgl_intersection( box_1, box_2 ).area();
+  return vgl_area( vgl_intersection( box_1, box_2 ) );
 }
 
 double

--- a/scoring_framework/score_phase1.cxx
+++ b/scoring_framework/score_phase1.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2010-2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2010-2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <typeinfo>
 
+#include <vgl/vgl_area.h>
 #include <vgl/vgl_box_2d.h>
 #include <vgl/vgl_intersection.h>
 
@@ -655,9 +656,9 @@ track2track_score
   {
     // it's pretty annoying but some of the code (e.g. score_phase2_aipr.cxx:60)
     // seems to rely on these being set ONLY if there is overlap
-    ret.truth_area = b1.area();
-    ret.computed_area = b2.area();
-    ret.overlap_area = bi.area();
+    ret.truth_area = vgl_area(b1);
+    ret.computed_area = vgl_area(b2);
+    ret.overlap_area = vgl_area(bi);
 
     double dx = b1.centroid_x() - b2.centroid_x();
     double d_center_y = b1.centroid_y() - b2.centroid_y();

--- a/scoring_framework/score_tracks.cxx
+++ b/scoring_framework/score_tracks.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2010-2016 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2010-2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -447,7 +447,7 @@ compute_normalization_factor( const phase1_parameters& p1_params,
     if (compute_norm)
     {
       double g = normalization_args.gsd(); // meters-per-pixel
-      double data_spatial_footprint = p1_params.b_aoi.area() * g * g; // m^2
+      double data_spatial_footprint = vgl_area(p1_params.b_aoi) * g * g; // m^2
       norm = data_spatial_footprint * normalization_args.norm_data_time(); // (m^2)*s
     }
   }

--- a/scoring_framework/score_tracks_loader.cxx
+++ b/scoring_framework/score_tracks_loader.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2011-2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2011-2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -15,6 +15,7 @@
 #include <limits>
 #include <stdexcept>
 
+#include <vgl/vgl_area.h>
 #include <vul/vul_file.h>
 #include <vul/vul_reg_exp.h>
 
@@ -724,7 +725,7 @@ check_for_zero_area_boxes( const vector< track_record_type >& records )
       frame_handle_list_type frames = track_oracle_core::get_frames( r_tracks[j] );
       for (size_t k=0; k<frames.size(); ++k)
       {
-        if (stt[ frames[k] ].bounding_box().area() <= 0)
+        if (vgl_area( stt[ frames[k] ].bounding_box() ) <= 0)
         {
           if (warn_count < 5 )
           {


### PR DESCRIPTION
I found that the ``vgl_box_2d`` class no longer has an area method (discovered via compilation error) and there is a node above the class that the ``vgl_area`` function should be used instead.

I never got to completely rebuild master due to some other compilation errors involving track_oracle, but I thought I would put up this branch anyway.