### PR TITLE
Change calls to area() on vgl_box to calls to vgl_area().

### DIFF
--- a/scoring_framework/quickfilter_box.cxx
+++ b/scoring_framework/quickfilter_box.cxx
@@ -9,6 +9,8 @@
 #include <stdexcept>
 #include <algorithm>
 
+#include <vgl_area.h>
+
 #ifdef KWANT_ENABLE_MGRS
 #include <track_oracle/file_formats/track_scorable_mgrs/track_scorable_mgrs.h>
 #endif
@@ -386,7 +388,7 @@ quickfilter_box_type
     vgl_box_2d<double> overlap = vgl_intersection( t1_box, t2_box );
     if (dbg) LOG_DEBUG( main_logger, "mgrs_box_intersect: boxes:\n" << t1_box << "\n" << t2_box << "\n" << overlap );
 
-    return (overlap.is_empty()) ? 0.0 : overlap.area();
+    return (overlap.is_empty()) ? 0.0 : vgl_area( overlap );
   }
 
   // if we get this far, we found no overlapping zones; the caller will
@@ -428,7 +430,7 @@ quickfilter_box_type
     return -1.0;
   }
 
-  return vgl_intersection( box_1, box_2 ).area();
+  return vgl_area( vgl_intersection( box_1, box_2 ));
 }
 
 double

--- a/scoring_framework/score_events.cxx
+++ b/scoring_framework/score_events.cxx
@@ -38,6 +38,8 @@ the activity index is used.
 #include <vul/vul_reg_exp.h>
 #include <vul/vul_timer.h>
 
+#include <vgl/vgl_area.h>
+
 #include <arrows/kpf/yaml/kpf_reader.h>
 #include <arrows/kpf/yaml/kpf_yaml_parser.h>
 #include <arrows/kpf/yaml/kpf_packet_header.h>
@@ -1110,14 +1112,14 @@ compute_normalization_factors(  const track_handle_list_type& truth_tracks,
   vgl_box_2d<double> ne_box;  // northing / easting box; assume the zones all match
   add_tracks_to_box( truth_tracks, ne_box );
   add_tracks_to_box( computed_tracks, ne_box );
-  LOG_INFO( main_logger, "Normalization: MGRS all-tracks AOI is " << ne_box.area() << " m^2" );
+  LOG_INFO( main_logger, "Normalization: MGRS all-tracks AOI is " << vgl_area( ne_box ) << " m^2" );
 
   timestamp_utilities::track_timestamp_stats_type tst_t( truth_tracks ), tst_c( computed_tracks );
   tst_t.combine_with_other( tst_c );
   double time_window_secs = (tst_t.minmax_ts.second - tst_t.minmax_ts.first) / 1.0e6;
   LOG_INFO( main_logger, "Normalization: all-tracks time window is " << time_window_secs << " seconds" );
 
-  double kmsq_in_box = ne_box.area() / 1.0e6;
+  double kmsq_in_box = vgl_area( ne_box ) / 1.0e6;
 
   // e.g. if area == 3 and time_window_secs = 120, then to get to FA / (km^2 per s),
   // divide FA count by (3 * 120)

--- a/scoring_framework/score_frames_aipr.cxx
+++ b/scoring_framework/score_frames_aipr.cxx
@@ -11,6 +11,7 @@
 #include <fstream>
 
 #include <vil/vil_math.h>
+#include <vgl/vgl_area.h>
 #include <vgl/vgl_point_3d.h>
 #include <vgl/vgl_distance.h>
 #include <vgl/vgl_intersection.h>
@@ -96,9 +97,12 @@ void compute_frame_based_metrics(vector<frame_based_metrics>& fbm,
         vgl_box_2d<unsigned> intersection = vgl_intersection(gt->history()[0]->amhi_bbox_,comp->history()[0]->amhi_bbox_);
 
         double overlap_score = 0;
-        if(intersection.area() != 0)
+        if( vgl_area( intersection ) != 0)
         {
-          overlap_score = (gt->history()[0]->amhi_bbox_.area()+comp->history()[0]->amhi_bbox_.area()-intersection.area())/intersection.area();
+          overlap_score = ( vgl_area( gt->history()[0]->amhi_bbox_) +
+                            vgl_area( comp->history()[0]->amhi_bbox_) -
+                            vgl_area( intersection ))
+            / vgl_area( intersection );
         }
 
         if(!intersection.is_empty() && overlap_score >= min_overlap_ratio)

--- a/scoring_framework/score_phase1.cxx
+++ b/scoring_framework/score_phase1.cxx
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <typeinfo>
 
+#include <vgl/vgl_area.h>
 #include <vgl/vgl_box_2d.h>
 #include <vgl/vgl_intersection.h>
 
@@ -655,9 +656,9 @@ track2track_score
   {
     // it's pretty annoying but some of the code (e.g. score_phase2_aipr.cxx:60)
     // seems to rely on these being set ONLY if there is overlap
-    ret.truth_area = b1.area();
-    ret.computed_area = b2.area();
-    ret.overlap_area = bi.area();
+    ret.truth_area = vgl_area( b1 );
+    ret.computed_area = vgl_area( b2 );
+    ret.overlap_area = vgl_area( bi );
 
     double dx = b1.centroid_x() - b2.centroid_x();
     double d_center_y = b1.centroid_y() - b2.centroid_y();

--- a/scoring_framework/score_tracks.cxx
+++ b/scoring_framework/score_tracks.cxx
@@ -447,7 +447,7 @@ compute_normalization_factor( const phase1_parameters& p1_params,
     if (compute_norm)
     {
       double g = normalization_args.gsd(); // meters-per-pixel
-      double data_spatial_footprint = p1_params.b_aoi.area() * g * g; // m^2
+      double data_spatial_footprint = vgl_area( p1_params.b_aoi ) * g * g; // m^2
       norm = data_spatial_footprint * normalization_args.norm_data_time(); // (m^2)*s
     }
   }

--- a/scoring_framework/score_tracks_loader.cxx
+++ b/scoring_framework/score_tracks_loader.cxx
@@ -18,6 +18,8 @@
 #include <vul/vul_file.h>
 #include <vul/vul_reg_exp.h>
 
+#include <vgl/vgl_area.h>
+
 #include <scoring_framework/score_core.h>
 #include <track_oracle/aries_interface/aries_interface.h>
 #include <track_oracle/file_formats/track_kwxml/file_format_kwxml.h>
@@ -724,7 +726,7 @@ check_for_zero_area_boxes( const vector< track_record_type >& records )
       frame_handle_list_type frames = track_oracle_core::get_frames( r_tracks[j] );
       for (size_t k=0; k<frames.size(); ++k)
       {
-        if (stt[ frames[k] ].bounding_box().area() <= 0)
+        if ( vgl_area( stt[ frames[k] ].bounding_box() ) <= 0)
         {
           if (warn_count < 5 )
           {


### PR DESCRIPTION
Recently VxL changed to remove the .area() method from vgl_box_2d and
instead use a vgl_area() function. This commit tracks that change by
changing calls from .area() to vgl_area( ... ).

This change should introduce no performance differences.