### PR TITLE
Improve handling of empty files in --paired-gtct.

### DIFF
--- a/scoring_framework/timestamp_utilities.h
+++ b/scoring_framework/timestamp_utilities.h
@@ -57,6 +57,7 @@ public:
   void update_from_frame( const kwto::frame_handle_type& f );
   void reset();
 
+  bool is_empty;
   bool has_frame_numbers;
   bool has_timestamps;
   bool all_have_frame_numbers;


### PR DESCRIPTION
When aggregating experiments via --paired-gtct, sometimes it may be
that either the computed data is empty (everything was missed), the
truth is empty (type filtering resulted in no true instances for that
particular data frame), or both.

The aggregation logic used by --paired-gtct didn't check correctly for
empty files, for example assuming the absence of timestamps was
automatically an error, even when the timestamps were missing because
the file was empty.

This commit:

- adds an explicit '.is_empty' flag to the track_timestamp_stats_type (TTS)

- checks for it when combining two TTS instances

- checks for it when conducting sanity checks processing --paired-gtct

- errors out if using time-windows with --paired-gtct (haven't ported that
over yet)